### PR TITLE
client recognizes connection_options

### DIFF
--- a/lib/fog/scaleway/account.rb
+++ b/lib/fog/scaleway/account.rb
@@ -47,8 +47,9 @@ module Fog
         include Fog::Scaleway::RequestHelper
 
         def initialize(options)
-          @token = options[:scaleway_token]
-          @email = options[:scaleway_email]
+          @token              = options[:scaleway_token]
+          @email              = options[:scaleway_email]
+          @connection_options = options[:connection_options] || {}
         end
 
         def request(params)
@@ -73,7 +74,7 @@ module Fog
         private
 
         def client
-          @client ||= Fog::Scaleway::Client.new('https://account.scaleway.com', @token)
+          @client ||= Fog::Scaleway::Client.new('https://account.scaleway.com', @token, @connection_options)
         end
 
         def camelize(str)

--- a/lib/fog/scaleway/client.rb
+++ b/lib/fog/scaleway/client.rb
@@ -1,9 +1,10 @@
 module Fog
   module Scaleway
     class Client
-      def initialize(endpoint, token)
-        @endpoint = endpoint
-        @token    = token
+      def initialize(endpoint, token, connection_options)
+        @endpoint           = endpoint
+        @token              = token
+        @connection_options = connection_options
       end
 
       def request(params)
@@ -23,7 +24,7 @@ module Fog
       private
 
       def connection
-        @connection ||= Fog::Core::Connection.new(@endpoint)
+        @connection ||= Fog::Core::Connection.new(@endpoint, false, @connection_options)
       end
 
       def encode_body(params)

--- a/lib/fog/scaleway/compute.rb
+++ b/lib/fog/scaleway/compute.rb
@@ -118,9 +118,10 @@ module Fog
         include Fog::Scaleway::RequestHelper
 
         def initialize(options)
-          @token        = options[:scaleway_token]
-          @organization = options[:scaleway_organization]
-          @region       = options[:scaleway_region] || 'par1'
+          @token              = options[:scaleway_token]
+          @organization       = options[:scaleway_organization]
+          @region             = options[:scaleway_region] || 'par1'
+          @connection_options = options[:connection_options] || {}
         end
 
         def request(params)
@@ -145,7 +146,7 @@ module Fog
         private
 
         def client
-          @client ||= Fog::Scaleway::Client.new(endpoint, @token)
+          @client ||= Fog::Scaleway::Client.new(endpoint, @token, @connection_options)
         end
 
         def endpoint


### PR DESCRIPTION
This commit adds a new parameter `connection_options` to the client. This e.g. allows specifying an http_proxy.

```ruby
Fog::Compute.new(
  :provider => :scaleway,
  :scaleway_token => api_token,
  :scaleway_organization => api_organization,
  :scaleway_region => region,
  :connection_options => {
    :proxy => 'http://localhost:3128'
  }
)
```